### PR TITLE
Add conditional to check for 'theme_get_setting'

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -301,8 +301,11 @@ function kalatheme_get_bootswatch_theme($theme) {
  * Helper function to return whether we are using libraries integration or not
  */
 function kalatheme_use_libraries() {
-  $library = theme_get_setting('bootstrap_library');
-  return (isset($library) && $library == 'custom');
+  if (function_exists('theme_get_setting')) {
+    $library = theme_get_setting('bootstrap_library');
+    return (isset($library) && $library == 'custom');
+  }
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
Add conditional to check for 'theme_get_setting'; this function isn't available until Drupal bootstraps, but because utils.inc is included in a chain of dependencies in a drush file, drush fails when trying to run basic commands on our travis server. This patch fixes that issue.
