### PR TITLE
fix(a11y): dropdown verbosity fix

### DIFF
--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -134,9 +134,10 @@ function kalatheme_links__system_main_menu($variables) {
       // If link has child items, print a toggle and dropdown menu.
       if (!empty($link['#below'])) {
         $dropdown_id = 'main-menu-dropdown-' . $i;
-        $output .= '<a href="#" class="dropdown-toggle dropdown-toggle-kt" data-toggle="dropdown" id="' . $dropdown_id. '" aria-haspopup="true" aria-expanded="false">';
+        $output .= '<a href="#" class="dropdown-toggle dropdown-toggle-kt" data-toggle="dropdown" id="' . $dropdown_id. '" aria-expanded="false">';
         //Add in text to be available for AT
-        $output .= '<span class="element-invisible">' . $link['#title'] . ' Submenu</span><span class="caret" aria-hidden="true"></span></a>';
+        $output .= '<span class="element-invisible">' . t('Dropdown: ') . $link['#title']. '</span>';
+        $output .= '<span class="caret" aria-hidden="true"></span></a>';
         $output .= theme('links__system_main_menu', array(
           'links' => $link['#below'],
           'attributes' => array(
@@ -207,7 +208,6 @@ function kalatheme_menu_local_task($variables) {
     $classes[] = 'dropdown';
     $link['localized_options']['attributes']['class'][] = 'dropdown-toggle';
     $link['localized_options']['attributes']['data-toggle'][] = 'dropdown';
-    $link['localized_options']['attributes']['aria-haspopup'][] = 'true';
     $link['localized_options']['attributes']['aria-expanded'][] = 'false';
     $link['href'] = '#';
     $link_text .= ' <span class="caret" aria-hidden="true"></span>';

--- a/src/dropdownExpand.coffee
+++ b/src/dropdownExpand.coffee
@@ -3,7 +3,6 @@ module.exports = ->
   $(->
     toggle = $('.dropdown-toggle')
     toggle.attr({
-      'aria-haspopup': 'true'
       'aria-expanded': 'false'
     })
     $('.dropdown').on('shown.bs.dropdown', (e) ->

--- a/test/specs/dropdownExpandSpec.coffee
+++ b/test/specs/dropdownExpandSpec.coffee
@@ -16,11 +16,8 @@ module.exports = () ->
       appendSetFixtures(container)
       )
     it('adds aria attributes', ->
-
-      expect(toggle).not.toHaveAttr('aria-haspopup','false')
       expect(toggle).not.toHaveAttr('aria-expanded','')
       dropdownExpand()
-      expect(toggle).toHaveAttr('aria-haspopup','true')
       expect(toggle).toHaveAttr('aria-expanded','false')
     )
     it('listens for the shown event', ->


### PR DESCRIPTION
- Removes [aria-haspopup] from dropdown toggles

![voiceover reading expanded internal link submenu](https://cloud.githubusercontent.com/assets/1218420/3322360/4afc07c2-f749-11e3-84a1-9b923ce119e7.png)
