### PR TITLE
fix(css): allows for longer link text node edit

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -2,7 +2,7 @@
 /////////////////////////
 
 
-// fixes checkbox alignment 
+// fixes checkbox alignment
 table .form-type-checkbox {
   input[type=checkbox],
   input[type=radio]{

--- a/scss/_panopoly.scss
+++ b/scss/_panopoly.scss
@@ -67,15 +67,15 @@
   margin-top: 5px;
 }
 
-/**
- * Menu Styling
- */
+// Menu styling for node edit form
 #node-edit .pane-node-form-menu .form-item-menu-parent label,#node-edit .pane-node-form-menu .form-item-menu-link-title label
   {
   float: left;
   font-weight: normal;
   margin-right: 4px;
-  width: 49px;
+  // Panopoly admin override for longer link text
+  // @link https://www.drupal.org/node/2295513
+  width: auto;
 }
 
 /**


### PR DESCRIPTION
- simple reset for allowing longer labels in the node edit form.
