### PR TITLE
#85 #80: Permissions can not be unset again

### DIFF
--- a/includes/core.inc
+++ b/includes/core.inc
@@ -478,7 +478,12 @@ function kalatheme_user_admin_permissions($variables) {
       );
       foreach (element_children($form['checkboxes']) as $rid) {
         $form['checkboxes'][$rid][$key]['#title'] = $roles[$rid] . ': ' . $form['permission'][$key]['#markup'];
-        $form['checkboxes'][$rid][$key]['#title_display'] = 'invisible';
+        // We are using a special title here for a couple reasons.
+        // If use invisible the checkboxes get put inside the label as per
+        // the bootstrap markup. However, this breaks the permissions UI
+        // and does not allow us to unset permissions. If we use none then
+        // we have no markup for screen readers.
+        $form['checkboxes'][$rid][$key]['#title_display'] = 'permissions';
         $row[] = array('data' => drupal_render($form['checkboxes'][$rid][$key]));
       }
     }

--- a/includes/fapi.inc
+++ b/includes/fapi.inc
@@ -161,6 +161,7 @@ function kalatheme_form_element($variables) {
 
   switch ($element['#title_display']) {
     case 'before':
+    case 'permissions':
     case 'invisible':
       $output .= ' ' . theme('form_element_label', $variables);
       $output .= ' ' . $prefix . $element['#children'] . $suffix . "\n";
@@ -213,7 +214,7 @@ function kalatheme_form_element_label($variables) {
   if ($element['#title_display'] == 'after' && !$is_radio_or_checkbox) {
     $attributes['class'] = 'option';
   }
-  elseif ($element['#title_display'] == 'invisible') {
+  elseif ($element['#title_display'] == 'invisible' || $element['#title_display'] == 'permissions') {
     $attributes['class'] = 'element-invisible';
   }
 
@@ -222,7 +223,7 @@ function kalatheme_form_element_label($variables) {
   }
 
   $output = '';
-  if ($is_radio_or_checkbox && isset($element['#children'])) {
+  if ($is_radio_or_checkbox && $element['#title_display'] != 'permissions' && isset($element['#children'])) {
     $output .= $element['#children'];
   }
 


### PR DESCRIPTION
This resolves an issue in kalatheme that prevents the user from being able to unset a permission on the permissions page.
