### PR TITLE
added javascript shims for bootstrap to work with jQuery 1.7

### DIFF
--- a/js/bootstrap_shims/README.md
+++ b/js/bootstrap_shims/README.md
@@ -1,4 +1,4 @@
-JQuery Shims
+Bootstrap JQuery 1.7 Shims
 ---------------------
 
 Currently the most current and Kalatheme compatible jQuery version is 1.7 (panopoly, ctools, IPE, etc.)

--- a/js/bootstrap_shims/README.md
+++ b/js/bootstrap_shims/README.md
@@ -1,0 +1,22 @@
+JQuery Shims
+---------------------
+
+Currently the most current and Kalatheme compatible jQuery version is 1.7 (panopoly, ctools, IPE, etc.)
+
+Bootstrap 3.2 (and some previous versions) set the jQuery dependency to 1.9 (which is hardly bleeding edge).
+
+These shims patch up certain bootstrap classes that dont seem to like jQuery 1.7, this is mostly due to the way in which callbacks are declared and copious use of 
+```
+var complete = function(){ … }
+$.one( 'bs.eventString', complete )
+```
+
+generally speaking setting an "onMethodComplete" callback to $.fn.bootstrapComponent.Constructor, and replacing the above with:
+
+```
+$.on('bs.eventString', this.onMethodComplete.bind( this ));
+```
+
+solves these issues. 
+
+We need to run the bootstrap jUnit tests with these overrides... but its a stable OOP solution. 

--- a/js/bootstrap_shims/README.md
+++ b/js/bootstrap_shims/README.md
@@ -14,9 +14,13 @@ $.one( 'bs.eventString', complete )
 generally speaking setting an "onMethodComplete" callback to $.fn.bootstrapComponent.Constructor, and replacing the above with:
 
 ```
-$.on('bs.eventString', this.onMethodComplete.bind( this ));
+var aThing = whateverIsHandlingTheEvent;
+aThing.on('bs.eventString', this.onMethodComplete.bind( this ));
 ```
-
-solves these issues. 
+and then from within the onMethodComplete method calling
+```
+whateverIsHandlingTheEvent.off('bs.eventString')
+```
+solves these issues (which is just longhand for what "$.fn.one" does.
 
 We need to run the bootstrap jUnit tests with these overrides... but its a stable OOP solution. 

--- a/js/bootstrap_shims/bs.carousel.override.js
+++ b/js/bootstrap_shims/bs.carousel.override.js
@@ -1,0 +1,83 @@
+(function($){
+
+  $.fn.carousel.Constructor.prototype.slide = function (type, next) {
+    var $active   = this.$element.find('.item.active')
+    var $next     = next || $active[type]()
+    var isCycling = this.interval
+    var direction = type == 'next' ? 'left' : 'right'
+    var fallback  = type == 'next' ? 'first' : 'last'
+    var that      = this
+
+    if (!$next.length) {
+      if (!this.options.wrap) return
+      $next = this.$element.find('.item')[fallback]()
+    }
+    if ($next.hasClass('active')) return (this.sliding = false)
+
+
+    var relatedTarget = $next[0]
+    var slideEvent = $.Event('slide.bs.carousel', {
+      relatedTarget: relatedTarget,
+      direction: direction
+    })
+    this.$element.trigger(slideEvent)
+    if (slideEvent.isDefaultPrevented()) return
+
+    this.sliding = true
+
+    isCycling && this.pause()
+
+    if (this.$indicators.length) {
+      // clear them all
+      this.$indicators.find('.active').removeClass('active')
+      var $nextIndicator = $(this.$indicators.children()[this.getItemIndex($next)])
+      $nextIndicator.addClass('active')
+    }
+
+    var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
+    if ($.support.transition && this.$element.hasClass('slide')) {
+      $next.addClass(type)
+      $next[0].offsetWidth // force reflow
+      $active.addClass(direction)
+      $next.addClass(direction)
+      $active.on('bsTransitionEnd', this.onSlideComplete.bind(this,[$next, $active, direction, type, slideEvent]))
+        .emulateTransitionEnd($active.css('transition-duration').slice(0, -1) * 1000 - 150);
+    } else {
+      $active.removeClass('active')
+      $next.addClass('active')
+      this.sliding = false
+      this.$element.trigger(slidEvent)
+    }
+
+    isCycling && this.cycle()
+
+    return this;
+  }
+
+  $.fn.carousel.Constructor.prototype.onSlideComplete = function( vars ){
+    this.sliding = false;
+      var $next = vars[0];
+      var $active = vars[1];
+      var direction = vars[2];
+      var type = vars[3];
+      var slidEvent = vars[4];
+      var that = this;
+      $active.off('bsTransitionEnd')
+      $next.removeClass(type);
+      $next.removeClass(direction);
+      $next.addClass('active');
+      $active.removeClass('active');
+      $active.removeClass(direction);
+      this.$element.find(".carousel-inner").css({
+        'max-height': $next.height()+"px",
+        'height': $next.height()+"px"
+      });
+      setTimeout(function () {
+        // console.log("trigger slid event!");
+        that.$element.trigger(slidEvent);
+      }, 0);
+      return this;
+  }
+
+
+}(jQuery));

--- a/js/bootstrap_shims/bs.carousel.override.js
+++ b/js/bootstrap_shims/bs.carousel.override.js
@@ -56,6 +56,9 @@
 
   $.fn.carousel.Constructor.prototype.onSlideComplete = function( vars ){
     this.sliding = false;
+      // hacky way to get at these variables
+      // might want to consider some currying
+      // https://medium.com/@kbrainwave/currying-in-javascript-ce6da2d324fe
       var $next = vars[0];
       var $active = vars[1];
       var direction = vars[2];

--- a/js/bootstrap_shims/bs.collapse.override.js
+++ b/js/bootstrap_shims/bs.collapse.override.js
@@ -1,0 +1,38 @@
+(function($){
+
+    $.fn.collapse.Constructor.prototype.hide = function () {
+
+      if (this.transitioning || !this.$element.hasClass('in')) return
+
+      var startEvent = $.Event('hide.bs.collapse')
+      this.$element.trigger(startEvent)
+      if (startEvent.isDefaultPrevented()) return
+
+      var dimension = this.dimension()
+
+      this.$element[dimension](this.$element[dimension]())[0].offsetHeight
+
+      this.$element
+        .addClass('collapsing')
+        .removeClass('collapse')
+        .removeClass('in')
+
+      this.transitioning = 1
+      var complete = function () {
+        this.transitioning = 0
+        this.$element
+          .trigger('hidden.bs.collapse')
+          .removeClass('collapsing')
+          .removeClass('in')
+          .addClass('collapse')
+      }
+
+      if (!$.support.transition) return complete.call(this)
+
+      this.$element
+        [dimension](0)
+        .one('bsTransitionEnd', $.proxy(complete, this))
+        .emulateTransitionEnd(350)
+    }
+
+}(jQuery));

--- a/js/bootstrap_shims/bs.tooltip.override.js
+++ b/js/bootstrap_shims/bs.tooltip.override.js
@@ -1,0 +1,141 @@
+(function ($) {
+
+  $.fn.tooltip.Constructor.enter = function (obj) {
+    var self = obj instanceof this.constructor ?
+      obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type)
+
+    clearTimeout(self.timeout)
+
+    self.hoverState = 'in'
+
+    if (!self.options.delay || !self.options.delay.show) return self.show()
+
+    self.timeout = setTimeout(function () {
+      if (self.hoverState == 'in') self.show()
+    }, self.options.delay.show)
+  }
+
+  $.fn.tooltip.Constructor.leave = function (obj) {
+    var self = obj instanceof this.constructor ?
+      obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type)
+
+    clearTimeout(self.timeout)
+
+    self.hoverState = 'out'
+
+    if (!self.options.delay || !self.options.delay.hide) return self.hide()
+
+    self.timeout = setTimeout(function () {
+      if (self.hoverState == 'out') self.hide()
+    }, self.options.delay.hide)
+  }
+
+  $.fn.tooltip.Constructor.show = function () {
+    var e = $.Event('show.bs.' + this.type)
+
+    if (this.hasContent() && this.enabled) {
+      this.$element.trigger(e)
+
+      if (e.isDefaultPrevented()) return
+      var that = this;
+
+      var $tip = this.tip()
+
+      this.setContent()
+
+      if (this.options.animation) $tip.addClass('fade')
+
+      var placement = typeof this.options.placement == 'function' ?
+        this.options.placement.call(this, $tip[0], this.$element[0]) :
+        this.options.placement
+
+      var autoToken = /\s?auto?\s?/i
+      var autoPlace = autoToken.test(placement)
+      if (autoPlace) placement = placement.replace(autoToken, '') || 'top'
+
+      $tip
+        .detach()
+        .css({ top: 0, left: 0, display: 'block' })
+        .addClass(placement)
+
+      this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+
+      var pos          = this.getPosition()
+      var actualWidth  = $tip[0].offsetWidth
+      var actualHeight = $tip[0].offsetHeight
+
+      if (autoPlace) {
+        var $parent = this.$element.parent()
+
+        var orgPlacement = placement
+        var docScroll    = document.documentElement.scrollTop || document.body.scrollTop
+        var parentWidth  = this.options.container == 'body' ? window.innerWidth  : $parent.outerWidth()
+        var parentHeight = this.options.container == 'body' ? window.innerHeight : $parent.outerHeight()
+        var parentLeft   = this.options.container == 'body' ? 0 : $parent.offset().left
+
+        placement = placement == 'bottom' && pos.top   + pos.height  + actualHeight - docScroll > parentHeight  ? 'top'    :
+                    placement == 'top'    && pos.top   - docScroll   - actualHeight < 0                         ? 'bottom' :
+                    placement == 'right'  && pos.right + actualWidth > parentWidth                              ? 'left'   :
+                    placement == 'left'   && pos.left  - actualWidth < parentLeft                               ? 'right'  :
+                    placement
+
+        $tip
+          .removeClass(orgPlacement)
+          .addClass(placement)
+      }
+
+      var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
+
+      this.applyPlacement(calculatedOffset, placement)
+      this.hoverState = null
+
+      if( $.support.transition && this.$tip.hasClass('fade') ){
+        $tip
+          .on($.support.transition.end, this.showComplete.bind(this))
+          .emulateTransitionEnd(150);
+      } else {
+        this.showComplete()
+      }
+    }
+  }
+
+  $.fn.tooltip.Constructor.showComplete = function() {
+    $tip = this.tip();
+    $tip.off($.support.transition.end);
+    this.$element.trigger('shown.bs.' + that.type)
+  }
+
+  $.fn.tooltip.Constructor.hideComplete = function() {
+    var $tip = this.tip();
+    $tip.off($.support.transition.end);
+      if (that.hoverState != 'in') $tip.detach()
+      that.$element.trigger('hidden.bs.' + that.type)
+
+  }
+
+  $.fn.tooltip.Constructor.hide = function () {
+
+    var that = this
+    var $tip = this.tip()
+    var e    = $.Event('hide.bs.' + this.type)
+
+    this.$element.trigger(e)
+
+    if (e.isDefaultPrevented()) return
+
+    $tip.removeClass('in')
+
+    if( $.support.transition && this.$tip.hasClass('fade') ) {
+      $tip
+        .on($.support.transition.end, this.hideComplete.bind(this))
+        .emulateTransitionEnd(150);
+    } else {
+      this.hideComplete()
+    }
+
+    this.hoverState = null
+
+    return this
+  }
+
+}(jQuery));

--- a/js/bootstrap_shims/bs.transition.end.override.js
+++ b/js/bootstrap_shims/bs.transition.end.override.js
@@ -1,0 +1,15 @@
+(function($){
+  // http://blog.alexmaccaw.com/css-transitions
+  $.fn.emulateTransitionEnd = function (duration) {
+    var called = false;
+    var $el = this;
+    var that = this;
+    $(this).on('bsTransitionEnd', function () {
+      called = true;
+      $(that).off('bsTransitionEnd');
+    })
+    var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
+    setTimeout(callback, duration)
+    return this
+  }
+}(jQuery));


### PR DESCRIPTION
Explanations in the README.md
I havent added the JS to the info file, as I imagine we should compile these down first (maybe along with the ctools modal override into a general compatability layer).

I'm happy to workshop this for eventual inclusion.
