### PR TITLE
Added check to prevent division by zero when determining responsive grid size

### DIFF
--- a/includes/views.inc
+++ b/includes/views.inc
@@ -47,7 +47,9 @@ function kalatheme_preprocess_views_view_grid(&$variables) {
     if (!$variables['options']['responsive_toggle']) {
       $variables['options']['columns_' . $tier] = 1;
     }
-    if ($variables['gridsize'] % $variables['options']['columns_' . $tier] === 0) {
+    if (!empty($variables['options']['columns_' . $tier]) &&
+      $variables['gridsize'] % $variables['options']['columns_' . $tier] === 0
+    ) {
       $variables[$tier] = $variables['gridsize'] / $variables['options']['columns_' . $tier];
     }
   }


### PR DESCRIPTION
#179 This PR implements a simple check to ensure the responsive tier isn’t empty or zero.
