### PR TITLE
Added necessary definitions for exporting views grids with bootstrap settings

### DIFF
--- a/views/plugins/views_plugin_style_grid_bootstrap.inc
+++ b/views/plugins/views_plugin_style_grid_bootstrap.inc
@@ -17,7 +17,11 @@ class views_plugin_style_grid_bootstrap extends views_plugin_style {
   function option_definition() {
     $options = parent::option_definition();
 
+    $options['responsive_toggle'] = array('default' => FALSE, 'bool' => TRUE);
+    $options['columns_lg'] = array('default' => '');
     $options['columns'] = array('default' => '4');
+    $options['columns_sm'] = array('default' => '');
+    $options['columns_xs'] = array('default' => '');
     $options['alignment'] = array('default' => 'horizontal');
     $options['fill_single_line'] = array('default' => TRUE, 'bool' => TRUE);
     $options['summary'] = array('default' => '');


### PR DESCRIPTION
Currently views export and features aren't aware of Kalatheme's views grid bootstrap options and thus won't export them. This PR fixes that by adding the options in the object's option_definition()
