### PR TITLE
Bootstrap checkboxes and radios 

### DIFF
--- a/css/panopoly.css
+++ b/css/panopoly.css
@@ -375,6 +375,15 @@ body.ctools-modal-open {
   display: block;
 }
 
+#modal-content .view-settings-wrapper .form-radio {
+	margin-left: -18px;
+}
+
+/* Differentiate group labels from radio labels. */
+#modal-content .form-group > label {
+  font-weight: 500;
+}
+
 ul.nav > li.dropdown:after {
   width: 100%;
   height: 2px;

--- a/css/tweaks.css
+++ b/css/tweaks.css
@@ -338,3 +338,26 @@ ul.panels-ipe-linkbar {
 .features-export-list .checkbox-inline input[type="checkbox"] {
   margin-left: 0px;
 }
+
+/* Bootstrap checkboxes and radios are styled with the assumption that they are 
+  preceeding a label but this isn't always the case e.g. Permissions page, 
+  features page etc */ 
+.form-item.radio input[type="radio"],
+.form-item.radio-inline input[type="radio"],
+.form-item.checkbox input[type="checkbox"],
+.form-item.checkbox-inline input[type="checkbox"],
+.form-item.checkbox label.element-invisible + input[type="checkbox"] {
+  position: static;
+  margin-left: 0;
+}
+
+.form-item.radio label input[type="radio"],
+.form-item.radio-inline label input[type="radio"],
+.form-item.checkbox label + input[type="checkbox"],
+.form-item.checkbox-inline label + input[type="checkbox"],
+.form-item.checkbox label input[type="checkbox"],
+.form-item.checkbox-inline label input[type="checkbox"] {
+  position: absolute;
+  margin-left: -20px;
+}
+

--- a/css/tweaks.css
+++ b/css/tweaks.css
@@ -328,14 +328,10 @@ ul.panels-ipe-linkbar {
   margin-left: 10px;
 }
 
-.features-export-component .radio input[type="radio"],
-.features-export-component .radio-inline input[type="radio"],
-.features-export-component .checkbox input[type="checkbox"],
-.features-export-component .checkbox-inline input[type="checkbox"],
-.features-export-list .radio input[type="radio"],
-.features-export-list .radio-inline input[type="radio"],
-.features-export-list .checkbox input[type="checkbox"],
-.features-export-list .checkbox-inline input[type="checkbox"] {
+table .radio input[type="radio"],
+table .radio-inline input[type="radio"],
+table .checkbox input[type="checkbox"],
+table .checkbox-inline input[type="checkbox"] {
   margin-left: 0px;
 }
 


### PR DESCRIPTION
are styled with the assumption that they are preceeding a label but this isn't always the case
