### PR TITLE
a11y: Remove "role='navigation'" from nav

### DIFF
--- a/includes/core.inc
+++ b/includes/core.inc
@@ -633,7 +633,10 @@ function kalatheme_pager($variables) {
     return '<nav class="text-center pagination-wrapper">' . theme('item_list', array(
       'plain' => true,
       'items' => $items,
-      'attributes' => array('class' => array('pager', 'pagination')),
+      'attributes' => array(
+        'class' => array('pager', 'pagination'),
+        'aria-label' => 'pager',
+      ),
     )) . '</nav>';
   }
 }

--- a/includes/core.inc
+++ b/includes/core.inc
@@ -630,7 +630,7 @@ function kalatheme_pager($variables) {
         'data' => $li_last,
       );
     }
-    return '<nav role="navigation" class="text-center pagination-wrapper">' . theme('item_list', array(
+    return '<nav class="text-center pagination-wrapper">' . theme('item_list', array(
       'plain' => true,
       'items' => $items,
       'attributes' => array('class' => array('pager', 'pagination')),


### PR DESCRIPTION
The nav element doesn't need to have the "navigation" role.